### PR TITLE
Add checks to re-create mirror if archive URI changes

### DIFF
--- a/mirror_mgmt/aptly/mirror.py
+++ b/mirror_mgmt/aptly/mirror.py
@@ -68,5 +68,5 @@ class Mirror(Resource):
         if show_details.returncode != 0:
             return True
 
-        repository = RE_URI.findall(show_details.stdout.decode(errors='ignore'))
-        return not repository or repository[0] != self.repository
+        repository = RE_URI.findall(show_details.stdout)
+        return not repository or repository[0].rstrip('/') != self.repository

--- a/mirror_mgmt/update.py
+++ b/mirror_mgmt/update.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 def update_mirrors() -> None:
     logger.debug('Updating mirrors')
     for mirror in get_manifest_mirrors():
-        if not mirror.exists:
+        if not mirror.needs_to_be_created():
             logger.info('Creating %r mirror', mirror.resource_name)
             mirror.create()
 

--- a/mirror_mgmt/update.py
+++ b/mirror_mgmt/update.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 def update_mirrors() -> None:
     logger.debug('Updating mirrors')
     for mirror in get_manifest_mirrors():
-        if not mirror.needs_to_be_created():
+        if mirror.needs_to_be_created():
             if mirror.exists:
                 logger.info('Removing %r mirror as it needs to be re-created', mirror.resource_name)
                 mirror.drop()

--- a/mirror_mgmt/update.py
+++ b/mirror_mgmt/update.py
@@ -10,6 +10,10 @@ def update_mirrors() -> None:
     logger.debug('Updating mirrors')
     for mirror in get_manifest_mirrors():
         if not mirror.needs_to_be_created():
+            if mirror.exists:
+                logger.info('Removing %r mirror as it needs to be re-created', mirror.resource_name)
+                mirror.drop()
+
             logger.info('Creating %r mirror', mirror.resource_name)
             mirror.create()
 


### PR DESCRIPTION
If the archive URI changes, we should be re-creating mirror as it would otherwise continue pulling in from the old archive URI which is not desired.