### PR TITLE
Allow to only publish snapshots of mirror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,8 @@ validate_manifest: check
 
 update-mirrors: backup update-mirrors-without-backup
 
+publish: backup
+	. ./venv-${COMMIT_HASH}/bin/activate && mirror_mgmt create_mirrors_snapshots -ps --snapshot-suffix=${SNAPSHOT_SUFFIX}
+
 # Sync and build all
 all: backup update-mirrors-without-backup


### PR DESCRIPTION
This commit adds another make target to only allow to publish snapshots of a mirror. This helps in cases when we don't want to update the mirror and just want to publish the existing mirror(s) with a different release name.