### PR TITLE
Remove dangling aptly snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ clean-mirrors: check
 
 clean: check clean-mirrors
 
+clean-dangling-snapshots: check
+	. ./venv-${COMMIT_HASH}/bin/activate && mirror_mgmt clean_dangling
+
 backup: check
 	. ./venv-${COMMIT_HASH}/bin/activate && mirror_mgmt backup
 

--- a/mirror_mgmt/aptly/snapshot.py
+++ b/mirror_mgmt/aptly/snapshot.py
@@ -7,6 +7,7 @@ from typing_extensions import ParamSpec
 
 from .resource import Resource
 from .run import aptly_run
+from .utils import get_all_published_snapshots, snapshot_is_published
 
 P = ParamSpec('P')
 
@@ -62,3 +63,6 @@ class Snapshot(Resource):
             raise CallError('Distribution must be specified when removing published snapshot')
 
         aptly_run(['publish', 'drop', self.snap_distribution, self.endpoint], check=False, log=False)
+
+    def is_published(self, published_snaps: str = None) -> bool:
+        return snapshot_is_published(self.resource_name, published_snaps or get_all_published_snapshots())

--- a/mirror_mgmt/aptly/snapshot.py
+++ b/mirror_mgmt/aptly/snapshot.py
@@ -7,7 +7,6 @@ from typing_extensions import ParamSpec
 
 from .resource import Resource
 from .run import aptly_run
-from .utils import get_all_published_snapshots, snapshot_is_published
 
 P = ParamSpec('P')
 
@@ -63,6 +62,3 @@ class Snapshot(Resource):
             raise CallError('Distribution must be specified when removing published snapshot')
 
         aptly_run(['publish', 'drop', self.snap_distribution, self.endpoint], check=False, log=False)
-
-    def is_published(self, published_snaps: str = None) -> bool:
-        return snapshot_is_published(self.resource_name, published_snaps or get_all_published_snapshots())

--- a/mirror_mgmt/aptly/utils.py
+++ b/mirror_mgmt/aptly/utils.py
@@ -1,5 +1,21 @@
+import re
+
 from .run import aptly_run
 
 
-def get_all_snapshots() -> str:
-    return aptly_run(['snapshot', 'list'], log=False).stdout
+def get_all_snapshots(get_raw: bool = False) -> str:
+    return aptly_run(['snapshot', 'list'] + (['-raw'] if get_raw else []), log=False).stdout
+
+
+def get_all_published_snapshots() -> str:
+    return aptly_run(['publish', 'list'], log=False).stdout
+
+
+def snapshot_is_published(snap_name: str, published_snapshots: str) -> bool:
+    return bool(
+        re.findall(fr'publishes\s*\{{.*:\s*\[{snap_name}\]:\s*Snapshot from mirror.*', published_snapshots)
+    )
+
+
+def drop_snapshot(snap_name: str):
+    aptly_run(['snapshot', 'drop', snap_name], log=False)

--- a/mirror_mgmt/aptly/utils.py
+++ b/mirror_mgmt/aptly/utils.py
@@ -13,9 +13,9 @@ def get_all_published_snapshots() -> str:
 
 def snapshot_is_published(snap_name: str, published_snapshots: str) -> bool:
     return bool(
-        re.findall(fr'publishes\s*\{{.*:\s*\[{snap_name}\]:\s*Snapshot from mirror.*', published_snapshots)
+        re.findall(fr'publishes\s*\{{.*:\s*\[{snap_name}\]:\s*Snapshot from.*', published_snapshots)
     )
 
 
-def drop_snapshot(snap_name: str):
+def drop_snapshot(snap_name: str) -> None:
     aptly_run(['snapshot', 'drop', snap_name], log=False)

--- a/mirror_mgmt/clean.py
+++ b/mirror_mgmt/clean.py
@@ -2,7 +2,8 @@ import logging
 
 from .aptly.mirror import Mirror
 from .aptly.resource import clean_database
-from .list import get_manifest_mirrors
+from .list import get_manifest_mirrors, get_snapshots
+from .clean_utils import remove_dangling_snapshots
 
 
 logger = logging.getLogger(__name__)
@@ -34,3 +35,8 @@ def clean_mirrors() -> None:
     logger.info('Cleaning aptly database')
     clean_database()
     logger.info('Successfully cleaned aptly database')
+
+
+def clean_dangling_snapshots() -> None:
+    logger.debug('Cleaning dangling snapshots')
+    remove_dangling_snapshots(get_snapshots())

--- a/mirror_mgmt/clean_utils.py
+++ b/mirror_mgmt/clean_utils.py
@@ -1,0 +1,15 @@
+import logging
+import typing
+
+from .aptly.utils import drop_snapshot, get_all_published_snapshots, snapshot_is_published
+
+
+logger = logging.getLogger(__name__)
+
+
+def remove_dangling_snapshots(snapshots: list, published_snaps: typing.Optional[str] = None):
+    published_snaps = published_snaps or get_all_published_snapshots()
+    for snapshot_name in snapshots:
+        if not snapshot_is_published(snapshot_name, published_snaps):
+            logger.info('Removing %r snapshot', snapshot_name)
+            drop_snapshot(snapshot_name)

--- a/mirror_mgmt/list.py
+++ b/mirror_mgmt/list.py
@@ -1,6 +1,11 @@
 from .aptly.mirror import Mirror
+from .aptly.utils import get_all_snapshots
 from .utils.manifest import get_manifest
 
 
 def get_manifest_mirrors() -> list:
     return [Mirror(**m) for m in get_manifest()['mirrors']]
+
+
+def get_snapshots() -> list:
+    return [s for s in filter(bool, map(str.strip, get_all_snapshots(True).split('\n')))]

--- a/mirror_mgmt/main.py
+++ b/mirror_mgmt/main.py
@@ -3,7 +3,7 @@ import coloredlogs
 import logging
 import sys
 
-from .clean import clean_mirrors
+from .clean import clean_dangling_snapshots, clean_mirrors
 from .create import create_mirrors
 from .snapshot import (
     backup_aptly_dataset, create_snapshots_of_mirrors, publish_snapshots_of_mirrors,
@@ -32,6 +32,7 @@ def main() -> None:
     subparsers = parser.add_subparsers(help='sub-command help', dest='action')
 
     subparsers.add_parser('clean_mirrors', help='Drop mirrors from the configuration provided')
+    subparsers.add_parser('clean_dangling', help='Drop unpublished aptly snapshots from the configuration provided')
     subparsers.add_parser(
         'create_mirrors', help='fCreate new mirrors from the configuration provided'
     )
@@ -60,6 +61,8 @@ def main() -> None:
         backup_aptly_dataset()
     elif args.action == 'clean_mirrors':
         clean_mirrors()
+    elif args.action == 'clean_dangling':
+        clean_dangling_snapshots()
     elif args.action == 'validate':
         validate(args.system_state, args.manifest)
     elif args.action == 'create_mirrors':

--- a/mirror_mgmt/main.py
+++ b/mirror_mgmt/main.py
@@ -71,7 +71,6 @@ def main() -> None:
     elif args.action == 'update_mirrors':
         validate()
         update_mirrors()
-        clean_dangling_snapshots()
     elif args.action == 'create_mirrors_snapshots':
         validate()
         snapshots = create_snapshots_of_mirrors(args.snapshot_suffix)

--- a/mirror_mgmt/main.py
+++ b/mirror_mgmt/main.py
@@ -71,10 +71,12 @@ def main() -> None:
     elif args.action == 'update_mirrors':
         validate()
         update_mirrors()
+        clean_dangling_snapshots()
     elif args.action == 'create_mirrors_snapshots':
         validate()
         snapshots = create_snapshots_of_mirrors(args.snapshot_suffix)
         if args.publish_snapshot:
             publish_snapshots_of_mirrors(snapshots)
+        clean_dangling_snapshots()
     else:
         parser.print_help()


### PR DESCRIPTION
The workflow for aptly mirrors is basically ( mirror -> snapshots -> published snapshots ), so when we update the mirror and take new snapshots but keep on using the same endpoint for publishing like `nightly`, the old snapshots just sit there having no published endpoint and consuming space.
Idea right now is to clean all dangling snapshots whenever we publish newer snapshots.