### PR TITLE
Fix makefile and add a retry script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ check:
 ifneq ($(REPO_CHANGED),0)
 	@echo "Setting up new virtual environment"
 	@rm -rf venv-*
-	@${PYTHON} -m pip install -U virtualenv >/dev/null 2>&1 || { echo "Failed to install/upgrade virtualenv package"; exit 1; }
+	@${PYTHON} -m pip install --break-system-packages -U virtualenv >/dev/null 2>&1 || { echo "Failed to install/upgrade virtualenv package"; exit 1; }
 	@${PYTHON} -m venv venv-${COMMIT_HASH} || { echo "Failed to create virutal environment"; exit 1; }
 	@{ . ./venv-${COMMIT_HASH}/bin/activate && \
 		python3 -m pip install -r requirements.txt >/dev/null 2>&1 && \

--- a/retry_script.sh
+++ b/retry_script.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+command_to_execute="make update-mirrors-without-backup"
+
+while true; do
+    $command_to_execute
+    exit_code=$?
+    if [ $exit_code -eq 0 ]; then
+        echo "Command exited successfully."
+        break
+    else
+        echo "Command exited with a non-zero exit code. Retrying..."
+        sleep 1
+    fi
+done


### PR DESCRIPTION
A retry script has been added since there are network issues which prevent updating mirrors and the command fails and we need to retry this again until it eventually succeeds.