### PR TITLE
Revert "Branch out mirrors to reflect 23.10.0 release"

### DIFF
--- a/conf/manifest.yaml
+++ b/conf/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 "gpg_key": "20998A97"
 "debian_release": "bookworm"
-"publish_prefix_default": "cobia/23.10.0"
+"publish_prefix_default": "cobia/nightlies"
 "release": "cobia"
 "aptly_dataset": "data/srv"
 "mirrors":


### PR DESCRIPTION
Reverts truenas/repo-mgmt#36